### PR TITLE
Gracefully handle pyMSVC import failures on Windows

### DIFF
--- a/build.py
+++ b/build.py
@@ -4,10 +4,18 @@ import os
 sys.path.append(os.getcwd())
 
 if sys.platform.startswith("win"):
-    import pyMSVC
-
-    environment = pyMSVC.setup_environment()
-    #print(environment)
+    try:
+        import pyMSVC  # type: ignore
+    except Exception as exc:  # pragma: no cover - best effort logging for build time failures
+        print(
+            "Warning: failed to import pyMSVC, continuing without MSVC environment auto-configuration."
+        )
+        print(f"Import error: {exc}")
+    else:
+        environment = pyMSVC.setup_environment()
+        if isinstance(environment, dict):
+            os.environ.update(environment)
+        # print(environment)
 
 import setuptools
 import numpy


### PR DESCRIPTION
## Summary
- guard the Windows-only pyMSVC import in the build script to avoid hard failures when the helper module cannot be imported
- update the environment with the values returned from pyMSVC only when they are available and log a warning otherwise

## Testing
- not run (Windows-specific change)


------
https://chatgpt.com/codex/tasks/task_e_690ae6efff3483248fc67489bcea8bf0