### PR TITLE
Fix poetry build workflow

### DIFF
--- a/.github/workflows/poetry-build.yml
+++ b/.github/workflows/poetry-build.yml
@@ -53,9 +53,7 @@ jobs:
         run: poetry install --no-interaction --no-root
 
       - name: Poetry build
-        run: |
-          source $VENV
-          poetry build
+        run: poetry build
 
       - name: Artifact name
         id: artifactname


### PR DESCRIPTION
### Motivation
- Prevent CI failures when the `VENV` environment variable is not set by removing an unnecessary virtualenv activation step in the Poetry build job.

### Description
- Simplify the `Poetry build` step in `.github/workflows/poetry-build.yml` by removing `source $VENV` and running `poetry build` directly.

### Testing
- No automated tests were run because this is a workflow-only change; CI will validate the workflow when the branch is pushed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6986a7cec2748324a245430e67fed9ba)