### PR TITLE
Fix Poetry installation in CI workflow

### DIFF
--- a/.github/workflows/poetry-build.yml
+++ b/.github/workflows/poetry-build.yml
@@ -38,10 +38,11 @@ jobs:
 
 
       - name: Install Poetry
-        uses: snok/install-poetry@v1
-        with:
-          virtualenvs-create: true
-          virtualenvs-in-project: true
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install "poetry==2.3.2"
+          poetry config virtualenvs.create true
+          poetry config virtualenvs.in-project true
       - name: Load cached venv
         id: cached-pip-wheels
         uses: actions/cache@v3


### PR DESCRIPTION
### Motivation
- The `snok/install-poetry` step in the CI workflow was failing to install Poetry, so the workflow needs a more reliable explicit installation and configuration step.

### Description
- Replaced the `snok/install-poetry@v1` action with a pip-based install of `poetry==2.3.2` and added `poetry config virtualenvs.create true` and `poetry config virtualenvs.in-project true` in `.github/workflows/poetry-build.yml`.

### Testing
- No automated tests were run because this is a workflow-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6986a9a3b4fc8324bd172275d9db3613)